### PR TITLE
Common: Add HFS (non-plus) volume support for generic data discs

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ pycryptodome = "*"
 enlighten = "*"
 pyisotools = "*"
 methodtools = "*"
+machfs = "*"
 
 [requires]
 python_version = "3.8"

--- a/common/factory.py
+++ b/common/factory.py
@@ -10,6 +10,7 @@ from pyisotools.iso import GamecubeISO
 
 from cdi.path_reader import CdiPathReader
 from common.iso_path_reader.methods.compressed import CompressedPathReader
+from common.iso_path_reader.methods.hfs import HfsPathReader
 from common.iso_path_reader.methods.pathlab import PathlabPathReader
 from common.iso_path_reader.methods.pycdlib import PyCdLibPathReader
 from common.processor import GenericIsoProcessor
@@ -18,6 +19,7 @@ from dreamcast.processor import DreamcastIsoProcessor
 from gamecube.path_reader import GamecubePathReader
 from gamecube.processor import GamecubeIsoProcessor
 from iso_accessor import IsoAccessor
+from machfs import Volume, Folder, File
 
 from cdi.processor import CdiIsoProcessor
 from cdi.utils import Disc
@@ -106,6 +108,16 @@ class IsoProcessorFactory:
             disc = WiiDisc(wrapper)
             iso = WiiISO.from_disc(fp.name, disc)
             return WiiPathReader(iso, fp)
+
+        # Apple formatted disc
+        wrapper.seek(0x430)
+        if wrapper.read(9) == b"Apple_HFS":
+            try:
+                volume = Volume()
+                volume.read(wrapper)
+                return HfsPathReader(volume, fp)
+            except ValueError:
+                pass
 
         wrapper.seek(0x800)
         if wrapper.peek(12) == b"PlayStation3":

--- a/common/iso_path_reader/methods/hfs.py
+++ b/common/iso_path_reader/methods/hfs.py
@@ -1,0 +1,69 @@
+import io
+
+from machfs import Folder
+
+from common.iso_path_reader.methods.base import IsoPathReader
+from dates import datetime_from_hfs_date
+
+
+class HfsPathReader(IsoPathReader):
+    def get_root_dir(self):
+        return self.iso
+
+    def iso_iterator(self, base_dir, recursive=False, include_dirs=False, base_path=tuple()):
+        for name, child in base_dir.items():
+            path = base_path + (name,)
+            child.path = "/".join(path)
+            if isinstance(child, Folder):
+                if recursive:
+                    if include_dirs:
+                        yield child
+                    yield from self.iso_iterator(child, recursive, include_dirs, path)
+                continue
+
+            yield child
+
+    def get_file_path(self, file):
+        return file.path
+
+    def get_file_date(self, file):
+        return datetime_from_hfs_date(file.crdate)
+
+    def get_file(self, path):
+        if path[0] == "/":
+            path = path[1:]
+
+        path = path.split("/")
+        try:
+            return self.iso[tuple(path)]
+        except KeyError:
+            raise FileNotFoundError
+
+    def open_file(self, file):
+        return io.BytesIO(file.data)
+
+    def get_file_hash(self, file, algo):
+        hash = algo()
+        with self.open_file(file) as f:
+            while chunk := f.read(65536):
+                hash.update(chunk)
+        return hash
+
+    def get_file_size(self, file):
+        return file.size
+
+    def get_file_sector(self, file):
+        return file.start_lba
+
+    def is_directory(self, file):
+        return isinstance(file, Folder)
+
+    def get_pvd(self):
+        return None
+
+    def get_pvd_info(self):
+        return {
+            "volume_identifier": self.iso.name,
+            "volume_creation_date": datetime_from_hfs_date(self.iso.crdate),
+            "volume_modification_date": datetime_from_hfs_date(self.iso.mddate)
+        }

--- a/dates.py
+++ b/dates.py
@@ -44,3 +44,7 @@ def datetime_from_iso_date(iso_date):
         dt = datetime.datetime.min
         dt = dt.replace(tzinfo=datetime.timezone.utc)
     return dt
+
+
+def datetime_from_hfs_date(seconds):
+    return datetime.datetime(1904,1,1, tzinfo=datetime.timezone.utc) + datetime.timedelta(seconds=seconds)

--- a/patches.py
+++ b/patches.py
@@ -23,3 +23,125 @@ def apply_patches():
         io.seek(offset)
         return io.read(length).decode(encoding, errors="ignore")
     pyisotools.iso.read_string = read_string
+
+    import machfs.main
+    import struct
+
+    from machfs import File, Folder, bitmanip, btree
+    from machfs.main import _link_aliases, _get_every_extent
+    # Patches the read function to allow more lazy data loading and add additional attributes
+    def read(self, from_volume):
+        offset = 0
+        from_volume.seek(0x400)
+        partition_start, = struct.unpack(">8xL", from_volume.read(12))
+        partition_start *= 512
+        if partition_start:
+            if from_volume[partition_start + 1024:partition_start + 1024 + 2] == b'H+':
+                raise ValueError('HFS+ not supported')
+            if from_volume[partition_start+1024:partition_start+1024+2] == b'BD':
+                offset = partition_start
+        if not offset:
+            for i in range(0, len(from_volume), 512):
+                if from_volume[i + 1024:i + 1024 + 2] == b'H+':
+                    raise ValueError('HFS+ not supported')
+                if from_volume[i+1024:i+1024+2] == b'BD':
+                    if i:
+                        offset = i
+                    break
+            else:
+                raise ValueError('Magic number not found in image')
+
+        drSigWord, drCrDate, drLsMod, drAtrb, drNmFls, \
+        drVBMSt, drAllocPtr, drNmAlBlks, drAlBlkSiz, drClpSiz, drAlBlSt, \
+        drNxtCNID, drFreeBks, drVN, drVolBkUp, drVSeqNum, \
+        drWrCnt, drXTClpSiz, drCTClpSiz, drNmRtDirs, drFilCnt, drDirCnt, \
+        drFndrInfo, drVCSize, drVBMCSize, drCtlCSize, \
+        drXTFlSize, drXTExtRec, \
+        drCTFlSize, drCTExtRec, \
+        = struct.unpack('>2sLLHHHHHLLHLH28pLHLLLHLL32sHHHL12sL12s', from_volume[1024 + offset:1024 + offset + 162])
+
+        self.crdate, self.mddate, self.bkdate = drCrDate, drLsMod, drVolBkUp
+        self.name = drVN.decode('mac_roman')
+
+        block2offset = lambda block: 512*drAlBlSt + drAlBlkSiz*block
+        getextentscontents = lambda extents: b''.join(from_volume[offset + block2offset(firstblk):offset + block2offset(firstblk+blkcnt)] for (firstblk, blkcnt) in extents)
+        getextents = lambda size, extrec1, cnid, fork: _get_every_extent((size+drAlBlkSiz-1)//drAlBlkSiz, extrec1, cnid, extoflow, fork)
+        getfork = lambda size, extrec1, cnid, fork: getextentscontents(_get_every_extent((size+drAlBlkSiz-1)//drAlBlkSiz, extrec1, cnid, extoflow, fork))[:size]
+
+        extoflow = {}
+        for rec in btree.dump_btree(getfork(drXTFlSize, drXTExtRec, 3, 'data')):
+            if rec[0] != 7: continue
+            xkrFkType, xkrFNum, xkrFABN, extrec = struct.unpack_from('>xBLH12s', rec)
+            if xkrFkType == 0xFF:
+                fork = 'rsrc'
+            elif xkrFkType == 0:
+                fork = 'data'
+            extoflow[xkrFNum, fork, xkrFABN] = extrec
+
+        cnids = {}
+        childlist = [] # list of (parent_cnid, child_name, child_object) tuples
+
+        prev_key = None
+        for rec in btree.dump_btree(getfork(drCTFlSize, drCTExtRec, 4, 'data')):
+            # create a directory tree from the catalog file
+            rec_len = rec[0]
+            if rec_len == 0: continue
+
+            key = rec[2:1+rec_len]
+            val = rec[bitmanip.pad_up(1+rec_len, 2):]
+
+            ckrParID, namelen = struct.unpack_from('>LB', key)
+            ckrCName = key[5:5+namelen]
+
+            datatype = (None, 'dir', 'file', 'dthread', 'fthread')[val[0]]
+            datarec = val[2:]
+
+            if datatype == 'dir':
+                dirFlags, dirVal, dirDirID, dirCrDat, dirMdDat, dirBkDat, dirUsrInfo, dirFndrInfo \
+                = struct.unpack_from('>HHLLLL16s16s', datarec)
+
+                f = Folder()
+                cnids[dirDirID] = f
+                childlist.append((ckrParID, ckrCName, f))
+
+                f.crdate, f.mddate, f.bkdate = dirCrDat, dirMdDat, dirBkDat
+
+            elif datatype == 'file':
+                filFlags, filTyp, filUsrWds, filFlNum, \
+                filStBlk, filLgLen, filPyLen, \
+                filRStBlk, filRLgLen, filRPyLen, \
+                filCrDat, filMdDat, filBkDat, \
+                filFndrInfo, filClpSize, \
+                filExtRec, filRExtRec, \
+                = struct.unpack_from('>BB16sLHLLHLLLLL16sH12s12sxxxx', datarec)
+
+                f = File()
+                cnids[filFlNum] = f
+                childlist.append((ckrParID, ckrCName, f))
+
+                f.crdate, f.mddate, f.bkdate = filCrDat, filMdDat, filBkDat
+                f.type, f.creator, f.flags, f.x, f.y = struct.unpack_from('>4s4sHHH', filUsrWds)
+
+                extents = getextents(filLgLen, filExtRec, filFlNum, 'data')
+                if extents:
+                    f.start_lba = block2offset(extents[0][0]) // 2048
+                else:
+                    f.start_lba = 0
+                f.size = filLgLen
+
+                f.data = getfork(filLgLen, filExtRec, filFlNum, 'data')
+                f.rsrc = getfork(filRLgLen, filRExtRec, filFlNum, 'rsrc')
+
+        for parent_cnid, child_name, child_obj in childlist:
+            if parent_cnid != 1:
+                parent_obj = cnids[parent_cnid]
+                parent_obj[child_name] = child_obj
+
+        self.update(cnids[2])
+
+        self.pop('Desktop', None)
+        self.pop('Desktop DB', None)
+        self.pop('Desktop DF', None)
+
+        _link_aliases(drCrDate, cnids)
+    machfs.main.Volume.read = read

--- a/utils/files.py
+++ b/utils/files.py
@@ -282,6 +282,21 @@ class BinWrapper(BaseFile):
             self.sector_offset = 0
             return
 
+        # Apple formatted disc
+        self.mmap.seek(0x430)
+        ident = self.mmap.read(9)
+        if ident == b"Apple_HFS":
+            self.sector_size = 2048
+            self.sector_offset = 0
+            return
+
+        self.mmap.seek(0x440)
+        ident = self.mmap.read(9)
+        if ident == b"Apple_HFS":
+            self.sector_size = 2352
+            self.sector_offset = 16
+            return
+
         # ISO9660 or CD-I discs
         self.mmap.seek(0x8001)
         ident = self.mmap.read(5)


### PR DESCRIPTION
Requires new dependency (machfs), and does not support more modern HFS+ volumes. Not extensively tested.