### PR TITLE
Improve ISO9660 and UDF parsing

### DIFF
--- a/common/iso_path_reader/methods/base.py
+++ b/common/iso_path_reader/methods/base.py
@@ -44,11 +44,11 @@ class IsoPathReader:
 
         info = {}
 
+        encoding = getattr(pvd, "encoding", "utf-8")
+
         for field in ("system_identifier", "volume_identifier", "volume_set_identifier"):
-            info[field] = getattr(pvd, field).strip(). \
-                decode(errors='replace'). \
-                encode("cp1252", errors="replace"). \
-                decode()
+            info[field] = getattr(pvd, field).rstrip(b"\x00"). \
+                decode(encoding=encoding, errors='replace').strip()
 
         for field in (
                 "volume_creation_date",

--- a/common/iso_path_reader/methods/pycdlib.py
+++ b/common/iso_path_reader/methods/pycdlib.py
@@ -80,15 +80,16 @@ class PyCdLibPathReader(ChunkedHashTrait, IsoPathReader):
     def open_file(self, file):
         # Hack: If multiple files reference the same LBA but with different
         # sizes, update the inode's data size to be correct for this file
-        if len(file.inode.linked_records) > 1 and file.inode.data_length != file.data_length:
-            LOGGER.warning("File %s marked at LBA %d, which was already marked for file %s",
-                           self.get_file_path(file), file.orig_extent_loc, self.get_file_path(file.inode.linked_records[0][0]))
-            for dr, _ in file.inode.linked_records:
-                if file == dr:
-                    file.inode.data_length = dr.data_length
-        # Hack #2. If the inode reports a negative or truncated value, force it to be the original size
-        if hasattr(file, "data_length") and file.inode.data_length < file.data_length:
-            file.inode.data_length = file.data_length
+        if hasattr(file, "data_length"):
+            if len(file.inode.linked_records) > 1 and file.inode.data_length != file.data_length:
+                LOGGER.warning("File %s marked at LBA %d, which was already marked for file %s",
+                               self.get_file_path(file), file.orig_extent_loc, self.get_file_path(file.inode.linked_records[0][0]))
+                for dr, _ in file.inode.linked_records:
+                    if file == dr:
+                        file.inode.data_length = dr.data_length
+            # Hack #2. If the inode reports a negative or truncated value, force it to be the original size
+            if hasattr(file, "data_length") and file.inode.data_length < file.data_length:
+                file.inode.data_length = file.data_length
 
         return pycdlib.pycdlibio.PyCdlibIO(file.inode, self.iso.logical_block_size)
 

--- a/common/iso_path_reader/methods/pycdlib.py
+++ b/common/iso_path_reader/methods/pycdlib.py
@@ -84,7 +84,7 @@ class PyCdLibPathReader(ChunkedHashTrait, IsoPathReader):
                     return self.get_file(path.upper())
                 if b'\xef\xbf\xbd' in path.encode():
                     for file in self.iso_iterator(self.get_root_dir(), recursive=True):
-                        if path == self.get_file_path(file):
+                        if path.lower() == self.get_file_path(file).lower():
                             return file
                 raise FileNotFoundError(e)
 

--- a/common/iso_path_reader/methods/pycdlib.py
+++ b/common/iso_path_reader/methods/pycdlib.py
@@ -82,10 +82,12 @@ class PyCdLibPathReader(ChunkedHashTrait, IsoPathReader):
             except PyCdlibInvalidInput:
                 if path.upper() != path:
                     return self.get_file(path.upper())
-                if b'\xef\xbf\xbd' in path.encode():
+                try:
                     for file in self.iso_iterator(self.get_root_dir(), recursive=True):
                         if path.lower() == self.get_file_path(file).lower():
                             return file
+                except Exception:
+                    pass
                 raise FileNotFoundError(e)
 
     def open_file(self, file):

--- a/common/iso_path_reader/methods/pycdlib.py
+++ b/common/iso_path_reader/methods/pycdlib.py
@@ -60,7 +60,13 @@ class PyCdLibPathReader(ChunkedHashTrait, IsoPathReader):
         return datetime_from_iso_date(file.date if not self.udf else file.mod_time)
 
     def get_file_size(self, file):
-        return file.get_data_length()
+        try:
+            return file.data_length
+        except AttributeError:
+            try:
+                return file.inode.data_length
+            except AttributeError:
+                return file.get_data_length()
 
     def get_file_sector(self, file):
         return file.orig_extent_loc

--- a/common/iso_path_reader/methods/pycdlib.py
+++ b/common/iso_path_reader/methods/pycdlib.py
@@ -97,6 +97,13 @@ class PyCdLibPathReader(ChunkedHashTrait, IsoPathReader):
         # Hack: If multiple files reference the same LBA but with different
         # sizes, update the inode's data size to be correct for this file
         if hasattr(file, "data_length"):
+            if not file.inode:
+                inode = pycdlib.inode.Inode()
+                inode.parse(file.extent_location(), file.data_length, self.fp,
+                          self.iso.logical_block_size)
+                f = pycdlib.pycdlibio.PyCdlibIO(inode, self.iso.logical_block_size)
+                return f
+
             if len(file.inode.linked_records) > 1 and file.inode.data_length != file.data_length:
                 LOGGER.warning("File %s marked at LBA %d, which was already marked for file %s",
                                self.get_file_path(file), file.orig_extent_loc, self.get_file_path(file.inode.linked_records[0][0]))

--- a/common/pycdlib.py
+++ b/common/pycdlib.py
@@ -327,6 +327,9 @@ class PyCdlib(_PyCdlib):
 
         return interchange_level, lastbyte
 
+    def _get_iso_size(self):
+        return float("inf")
+
 # Volume descriptor parsers with HS filesystem support
 class PrimaryOrSupplementaryVD(_PrimaryOrSupplementaryVD):
     FMT_HS = '<B5sBB32s32sQLL32sHHHHHHLLLLLLLLLL34s128s128s128s128s37s37s17s17s17s17sBB512s653s'

--- a/common/pycdlib.py
+++ b/common/pycdlib.py
@@ -109,7 +109,10 @@ class PyCdlib(_PyCdlib):
             pvd.root_dir_record = self.pvd.root_dir_record
 
         if not self.vdsts:
-            raise pycdlibexception.PyCdlibInvalidISO('Valid ISO9660 filesystems must have at least one Volume Descriptor Set Terminator')
+            vdsts = VolumeDescriptorSetTerminator()
+            vdsts.new()
+            vdsts.set_extent_location(0)
+            self.vdsts.append(vdsts)
 
     def _parse_path_table(self, ptr_size, extent):
         # type: (int, int) -> Tuple[List[path_table_record.PathTableRecord], Dict[int, path_table_record.PathTableRecord]]

--- a/common/pycdlib.py
+++ b/common/pycdlib.py
@@ -333,9 +333,6 @@ class PyCdlib(_PyCdlib):
 # Volume descriptor parsers with HS filesystem support
 class PrimaryOrSupplementaryVD(_PrimaryOrSupplementaryVD):
     FMT_HS = '<B5sBB32s32sQLL32sHHHHHHLLLLLLLLLL34s128s128s128s128s37s37s17s17s17s17sBB512s653s'
-    def __init__(self, vd_type):
-        super().__init__(vd_type)
-        self.root_dir_record = HsDirectoryRecord()
 
     def parse(self, vd, ident, extent_loc):
         # type: (bytes, bytes, int) -> None
@@ -349,30 +346,43 @@ class PrimaryOrSupplementaryVD(_PrimaryOrSupplementaryVD):
         Returns:
          Nothing.
         """
-        if ident != b'CDROM':
-            return super().parse(vd, extent_loc)
-
         ################ PVD VERSION ######################
-        (descriptor_type, identifier, self.version, self.flags,
-         self.system_identifier, self.volume_identifier, unused1,
-         space_size_le, space_size_be, self.escape_sequences, set_size_le,
-         set_size_be, seqnum_le, seqnum_be, logical_block_size_le,
-         logical_block_size_be, path_table_size_le, path_table_size_be,
-         self.path_table_location_le, opt_path_table_1_le, opt_path_table_2_le,
-         opt_path_table_3_le, self.path_table_location_be, opt_path_table_1_be,
-         opt_path_table_2_be, opt_path_table_3_msb,
-         root_dir_record, self.volume_set_identifier, pub_ident_str,
-         prepare_ident_str, app_ident_str, self.copyright_file_identifier,
-         self.abstract_file_identifier,vol_create_date_str, vol_mod_date_str,
-         vol_expire_date_str, vol_effective_date_str, self.file_structure_version,
-         unused2, self.application_use, zero_unused) = struct.unpack_from(self.FMT_HS, vd, 0)
+        if ident == b'CD001':
+            (descriptor_type, identifier, self.version, self.flags,
+             self.system_identifier, self.volume_identifier, unused1,
+             space_size_le, space_size_be, self.escape_sequences, set_size_le,
+             set_size_be, seqnum_le, seqnum_be, logical_block_size_le,
+             logical_block_size_be, path_table_size_le, path_table_size_be,
+             self.path_table_location_le, self.optional_path_table_location_le,
+             self.path_table_location_be, self.optional_path_table_location_be,
+             root_dir_record, self.volume_set_identifier, pub_ident_str,
+             prepare_ident_str, app_ident_str, self.copyright_file_identifier,
+             self.abstract_file_identifier, self.bibliographic_file_identifier,
+             vol_create_date_str, vol_mod_date_str, vol_expire_date_str,
+             vol_effective_date_str, self.file_structure_version, unused2,
+             self.application_use, zero_unused) = struct.unpack_from(self.FMT, vd, 0)
+        else:
+            (descriptor_type, identifier, self.version, self.flags,
+             self.system_identifier, self.volume_identifier, unused1,
+             space_size_le, space_size_be, self.escape_sequences, set_size_le,
+             set_size_be, seqnum_le, seqnum_be, logical_block_size_le,
+             logical_block_size_be, path_table_size_le, path_table_size_be,
+             self.path_table_location_le, opt_path_table_1_le, opt_path_table_2_le,
+             opt_path_table_3_le, self.path_table_location_be, opt_path_table_1_be,
+             opt_path_table_2_be, opt_path_table_3_msb,
+             root_dir_record, self.volume_set_identifier, pub_ident_str,
+             prepare_ident_str, app_ident_str, self.copyright_file_identifier,
+             self.abstract_file_identifier,vol_create_date_str, vol_mod_date_str,
+             vol_expire_date_str, vol_effective_date_str, self.file_structure_version,
+             unused2, self.application_use, zero_unused) = struct.unpack_from(self.FMT_HS, vd, 0)
+            self.root_dir_record = HsDirectoryRecord()
 
         # According to Ecma-119, 8.4.1, the primary volume descriptor type
         # should be 1.
         if descriptor_type != self._vd_type:
             raise pycdlibexception.PyCdlibInvalidISO('Invalid volume descriptor')
         # According to Ecma-119, 8.4.2, the identifier should be 'CD001'.
-        if identifier != b'CDROM':
+        if identifier not in [b'CDROM', b'CD001']:
             raise pycdlibexception.PyCdlibInvalidISO('invalid CD isoIdentification')
         # According to Ecma-119, 8.4.3, the version should be 1 (or 2 for
         # ISO9660:1999)
@@ -384,10 +394,7 @@ class PrimaryOrSupplementaryVD(_PrimaryOrSupplementaryVD):
         # According to Ecma-119, 8.4.4, the first flags field should be 0 for a Primary.
         if self._vd_type == headervd.VOLUME_DESCRIPTOR_TYPE_PRIMARY and self.flags != 0:
             raise pycdlibexception.PyCdlibInvalidISO('PVD flags field is not zero')
-        # According to Ecma-119, 8.4.5, the first unused field (after the
-        # system identifier and volume identifier) should be 0.
-        if unused1 != 0:
-            raise pycdlibexception.PyCdlibInvalidISO('data in 2nd unused field not zero')
+
         # According to Ecma-119, 8.4.9, the escape sequences for a PVD should
         # be 32 zero-bytes.  However, we have seen ISOs in the wild (Fantastic
         # Night Dreams - Cotton Original (Japan).cue from the psx redump

--- a/common/pycdlib.py
+++ b/common/pycdlib.py
@@ -129,7 +129,16 @@ class PyCdlib(_PyCdlib):
          dictionary of the extent locations to the path table record entries.
         """
         if not self.is_hs:
-            return super()._parse_path_table(ptr_size, extent)
+            try:
+                return super()._parse_path_table(ptr_size, extent)
+            except:
+                extent = getattr(extent, "real", extent)
+                if extent == getattr(self.pvd.path_table_location_le, "real", self.pvd.path_table_location_be):
+                    return super()._parse_path_table(ptr_size, self.pvd.path_table_location_le)
+                if self.joliet_vd and extent == getattr(self.joliet_vd.path_table_location_be, "real", self.joliet_vd.path_table_location_be):
+                    return super()._parse_path_table(ptr_size, self.joliet_vd.path_table_location_le)
+                raise
+
 
         self._seek_to_extent(extent)
         old = self._cdfp.tell()

--- a/common/pycdlib.py
+++ b/common/pycdlib.py
@@ -2,6 +2,7 @@
 Modified versions of PyCdlib classes that support High Sierra format (a predecessor to ISO9660)
 """
 import collections
+import logging
 import os
 import struct
 import pycdlib.udf as udfmod
@@ -12,6 +13,7 @@ from pycdlib.headervd import VolumeDescriptorSetTerminator as _VolumeDescriptorS
 from pycdlib.dr import DirectoryRecord as _DirectoryRecord, XARecord
 from pycdlib.pycdlib import _interchange_level_from_directory, _interchange_level_from_filename
 
+_logger = logging.getLogger(__name__)
 
 class PyCdlib(_PyCdlib):
     is_hs = False
@@ -102,7 +104,7 @@ class PyCdlib(_PyCdlib):
         # Make sure any other PVDs agree with the first one.
         for pvd in self.pvds[1:]:
             if pvd != self.pvd:
-                raise pycdlibexception.PyCdlibInvalidISO('Multiple occurrences of PVD did not agree!')
+                _logger.warning('Multiple occurrences of PVD did not agree!')
 
             pvd.root_dir_record = self.pvd.root_dir_record
 

--- a/common/udf/pycdlib_udf.py
+++ b/common/udf/pycdlib_udf.py
@@ -3,7 +3,7 @@ import functools
 import os
 import struct
 
-from pycdlib import PyCdlib, pycdlibexception, headervd, inode
+from pycdlib import PyCdlib, pycdlibexception, headervd, inode, pycdlib
 from pycdlib import udf as udfmod
 
 allzero = b'\x00' * 2048
@@ -236,7 +236,7 @@ class PyCdlibUdf(PyCdlib):
 
         for anchor in self.udf_anchors[1:]:
             if self.udf_anchors[0] != anchor:
-                raise pycdlibexception.PyCdlibInvalidISO('Anchor points do not match')
+                pycdlib._logger.warning('UDF anchor points do not match')
 
         if desc_tag.tag_ident != 256:
             raise pycdlibexception.PyCdlibInvalidISO('UDF File Set Tag identifier not 256')

--- a/common/udf/pycdlib_udf.py
+++ b/common/udf/pycdlib_udf.py
@@ -335,9 +335,6 @@ class PyCdlibUdf(PyCdlib):
                 udf_file_entry.track_file_ident_desc(file_ident)
 
                 if next_entry is None:
-                    if file_ident.is_dir():
-                        raise pycdlibexception.PyCdlibInvalidISO('Empty UDF File Entry for directories are not allowed')
-
                     # If the next_entry is None, then we just skip the
                     # rest of the code dealing with the entry and the
                     # Inode.

--- a/common/udf/pycdlib_udf.py
+++ b/common/udf/pycdlib_udf.py
@@ -50,7 +50,7 @@ class PyCdlibUdf(PyCdlib):
             anchor_tag = udfmod.UDFTag()
             try:
                 anchor_tag.parse(anchor_data, extent)
-            except pycdlibexception.PyCdlibInvalidISO:
+            except (pycdlibexception.PyCdlibInvalidISO, struct.error):
                 continue
             if anchor_tag.tag_ident != 2:
                 continue

--- a/common/udf/pycdlib_udf.py
+++ b/common/udf/pycdlib_udf.py
@@ -249,12 +249,15 @@ class PyCdlibUdf(PyCdlib):
         current_extent += 1
         # FIXME: deal with running out of space on the Partition
         terminating_data = self._cdfp.read(self.logical_block_size)
-        desc_tag = udfmod.UDFTag()
-        desc_tag.parse(terminating_data,
-                       current_extent - self.udf_main_descs.partitions[0].part_start_location)
-        if desc_tag.tag_ident == 8:
-            self.udf_file_set_terminator = udfmod.UDFTerminatingDescriptor()
-            self.udf_file_set_terminator.parse(current_extent, desc_tag)
+        try:
+            desc_tag = udfmod.UDFTag()
+            desc_tag.parse(terminating_data,
+                           current_extent - self.udf_main_descs.partitions[0].part_start_location)
+            if desc_tag.tag_ident == 8:
+                self.udf_file_set_terminator = udfmod.UDFTerminatingDescriptor()
+                self.udf_file_set_terminator.parse(current_extent, desc_tag)
+        except pycdlibexception.PyCdlibInvalidISO:
+            pass
 
     def _walk_udf_directories(self, extent_to_inode):
         # type: (Dict[int, inode.Inode]) -> None

--- a/common/udf/pycdlib_udf.py
+++ b/common/udf/pycdlib_udf.py
@@ -295,6 +295,9 @@ class PyCdlibUdf(PyCdlib):
                 data += self._cdfp.read(desc.extent_length)
             offset = 0
             while offset < len(data):
+                if data[offset:] == b"\x00" * len(data[offset:]):
+                    offset = len(data)
+                    continue
                 current_extent = (abs_file_ident_extent * self.logical_block_size + offset) // self.logical_block_size
 
                 desc_tag = udfmod.UDFTag()

--- a/dates.py
+++ b/dates.py
@@ -5,20 +5,28 @@ from pycdlib.udf import UDFTimestamp
 
 def datetime_from_iso_date(iso_date):
     year = None
+    tz = None
     if isinstance(iso_date, VolumeDescriptorDate):
         year = iso_date.year
         day = iso_date.dayofmonth
-        tz = datetime.timezone(datetime.timedelta(minutes=15 * iso_date.gmtoffset))
     elif isinstance(iso_date, DirectoryRecordDate):
         year = 1900 + iso_date.years_since_1900
         day = iso_date.day_of_month
-        tz = datetime.timezone(datetime.timedelta(minutes=15 * iso_date.gmtoffset))
     elif isinstance(iso_date, UDFTimestamp):
         year = iso_date.year
         day = iso_date.day
-        tz = datetime.timezone(datetime.timedelta(minutes=iso_date.tz))
+        if tz:
+            tz = datetime.timezone(datetime.timedelta(minutes=iso_date.tz))
+        else:
+            tz = datetime.timezone.utc
     else:
         return None
+
+    if not tz:
+        try:
+            tz = datetime.timezone(datetime.timedelta(minutes=15 * iso_date.gmtoffset))
+        except ValueError:
+            tz = datetime.timezone.utc
 
     if not year:
         return None

--- a/patches.py
+++ b/patches.py
@@ -29,6 +29,21 @@ def apply_patches():
     pycdlib.utils.swab_32bit = swab_32bit
     pycdlib.utils.swab_16bit = swab_16bit
 
+    # Hack to keep iso entries in the correct order in pycdlib
+    import pycdlib.dr
+    orig_add_child = pycdlib.dr.DirectoryRecord._add_child
+    def _add_child(self, child, *args, **kwargs):
+        ret = orig_add_child(self, child, *args, **kwargs)
+        try:
+            idx = self.children.index(child)
+            if idx != len(self.children) - 1:
+                self.children.pop(idx)
+                self.children.append(child)
+        except ValueError:
+            pass
+        return ret
+    pycdlib.dr.DirectoryRecord._add_child = _add_child
+
     def read_string(io, offset: int = 0, maxlen: int = 0, encoding: str = "ascii") -> str:
         """ Reads a null terminated string from the specified address """
 

--- a/ps3/path_reader.py
+++ b/ps3/path_reader.py
@@ -1,4 +1,5 @@
 import collections
+import functools
 import io
 import logging
 import math
@@ -153,7 +154,8 @@ class Ps3PathReader(PyCdLibPathReader):
         for region in self.regions:
             if region.start <= file.inode.fp_offset < region.end:
                 if region.encrypted:
-                    return DecryptedFileReader(file.inode, self.iso.logical_block_size, self.disc_key)
+                    io_class = functools.partial(DecryptedFileReader, disc_key=self.disc_key)
+                    return super().open_file(file, io_class)
                 else:
                     return super().open_file(file)
         return super().open_file(file)

--- a/utils/mmap.py
+++ b/utils/mmap.py
@@ -6,6 +6,7 @@ class FakeMemoryMap(object):
     def __init__(self, f):
         self._lock = threading.Lock()
         self._file = f
+        self.name = getattr(f, "name", "")
         with self._lock:
             f.seek(0, io.SEEK_END)
             self._size = f.tell()


### PR DESCRIPTION
Handle more out of spec issues in ISO9660 and UDF isos
Add support for UDF virtual partitions and fragmented files
Better filename decoding
Support for more UDF structures
Lessen some errors into warnings
Support very large files in ISO9660 volumes via data continuation records